### PR TITLE
Feat(libraries): add Leaflet versions [1.0.1 - 1.0.3]

### DIFF
--- a/public/js/editors/libraries.js
+++ b/public/js/editors/libraries.js
@@ -9,6 +9,30 @@ var libraries = [
   },
   {
     'url': [
+      'https://unpkg.com/leaflet@1.0.3/dist/leaflet.css',
+      'https://unpkg.com/leaflet@1.0.3/dist/leaflet-src.js'
+    ],
+    'label': 'Leaflet 1.0.3',
+    'group': 'Leaflet'
+  },
+  {
+    'url': [
+      'https://unpkg.com/leaflet@1.0.2/dist/leaflet.css',
+      'https://unpkg.com/leaflet@1.0.2/dist/leaflet-src.js'
+    ],
+    'label': 'Leaflet 1.0.2',
+    'group': 'Leaflet'
+  },
+  {
+    'url': [
+      'https://unpkg.com/leaflet@1.0.1/dist/leaflet.css',
+      'https://unpkg.com/leaflet@1.0.1/dist/leaflet-src.js'
+    ],
+    'label': 'Leaflet 1.0.1',
+    'group': 'Leaflet'
+  },
+  {
+    'url': [
       'https://unpkg.com/leaflet@1.0.0/dist/leaflet.css',
       'https://unpkg.com/leaflet@1.0.0/dist/leaflet-src.js'
     ],


### PR DESCRIPTION
so that it is easier to make up live test cases and it avoids confusion about maintained / available versions.

Added versions: 1.0.1, 1.0.2, 1.0.3 (using unkpg.com CDN)